### PR TITLE
gomod parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The `tree_sitter.xcframework` binary comes with:
 - [tree-sitter](https://tree-sitter.github.io/tree-sitter) runtime
 - [tree-sitter-swift](https://github.com/alex-pinkus/tree-sitter-swift)
 - [tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go)
+- [tree-sitter-gomod](https://github.com/camdencheek/tree-sitter-go-mod)
 - [tree-sitter-ruby](https://github.com/tree-sitter/tree-sitter-ruby)
 - [tree-sitter-json](https://github.com/tree-sitter/tree-sitter-json)
 

--- a/scripts/build-tree-sitter.sh
+++ b/scripts/build-tree-sitter.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -euxo pipefail
+
 BASE_PWD="$PWD"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 TMP_BUILD_DIR=$( mktemp -d )
@@ -40,6 +42,16 @@ LDFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 $(pkg-config tree-s
 PREFIX=$TMP_BUILD_DIR/build make install
 popd
 
+git clone https://github.com/camdencheek/tree-sitter-go-mod.git
+
+pushd tree-sitter-go-mod
+npm install
+CFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -std=gnu99 -O3" \
+CXXFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3" \
+LDFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13" \
+PREFIX=$TMP_BUILD_DIR/build make install
+popd
+
 git clone https://github.com/tree-sitter/tree-sitter-ruby.git
 
 pushd tree-sitter-ruby
@@ -66,6 +78,7 @@ libtool -static -o libtree-sitter.a \
     $TMP_BUILD_DIR/build/lib/libtree-sitter.a \
     $TMP_BUILD_DIR/build/lib/libtree-sitter-swift.a \
     $TMP_BUILD_DIR/build/lib/libtree-sitter-go.a \
+    $TMP_BUILD_DIR/build/lib/libtree-sitter-gomod.a \
     $TMP_BUILD_DIR/build/lib/libtree-sitter-ruby.a \
     $TMP_BUILD_DIR/build/lib/libtree-sitter-json.a
 

--- a/shim/tree_sitter.h
+++ b/shim/tree_sitter.h
@@ -2,5 +2,6 @@
 #include <tree_sitter/parser.h>
 #include <tree_sitter/tree-sitter-swift.h>
 #include <tree_sitter/go.h>
+#include <tree_sitter/gomod.h>
 #include <tree_sitter/ruby.h>
 #include <tree_sitter/tree-sitter-json.h>

--- a/tree_sitter.xcframework/macos-arm64_x86_64/tree_sitter.framework/Versions/A/Headers/gomod.h
+++ b/tree_sitter.xcframework/macos-arm64_x86_64/tree_sitter.framework/Versions/A/Headers/gomod.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_GOMOD_H_
+#define TREE_SITTER_GOMOD_H_
+
+#include <tree_sitter/parser.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_gomod();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_GOMOD_H_

--- a/tree_sitter.xcframework/macos-arm64_x86_64/tree_sitter.framework/Versions/A/Headers/tree_sitter.h
+++ b/tree_sitter.xcframework/macos-arm64_x86_64/tree_sitter.framework/Versions/A/Headers/tree_sitter.h
@@ -2,5 +2,6 @@
 #include <tree_sitter/parser.h>
 #include <tree_sitter/tree-sitter-swift.h>
 #include <tree_sitter/go.h>
+#include <tree_sitter/gomod.h>
 #include <tree_sitter/ruby.h>
 #include <tree_sitter/tree-sitter-json.h>


### PR DESCRIPTION
This includes another parser for Go mod files.

I also made one small change to the build script. This will interrupt the script if any one step fails. Helps to track down issues, and prevent accidentally producing a broken framework.