### PR TITLE
Make sure to link to the built copy of libtree-sitter.a

### DIFF
--- a/scripts/build-tree-sitter.sh
+++ b/scripts/build-tree-sitter.sh
@@ -7,8 +7,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 TMP_BUILD_DIR=$( mktemp -d )
 mkdir $TMP_BUILD_DIR/build
 
-PKG_CONFIG_PATH="$TMP_BUILD_DIR/build/lib/pkgconfig"
-export PKG_CONFIG_PATH=$(pkg-config --variable pc_path pkg-config)${PKG_CONFIG_PATH:+:}${PKG_CONFIG_PATH}
+COMMON_FLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13"
+TREE_SITTER_CFLAGS="${COMMON_FLAGS} -std=gnu99 -O3 -Wall -Wextra -I${TMP_BUILD_DIR}/tree-sitter/lib/include/"
+TREE_SITTER_CXXFLAGS="${COMMON_FLAGS} -O3 -Wall -Wextra -I${TMP_BUILD_DIR}/tree-sitter/lib/include/"
+TREE_SITTER_LDFLAGS="${COMMON_FLAGS} -L${TMP_BUILD_DIR}/tree-sitter"
 
 pushd $TMP_BUILD_DIR
 
@@ -16,9 +18,9 @@ git clone https://github.com/tree-sitter/tree-sitter.git
 
 pushd tree-sitter
 git checkout v0.20.6
-CFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -std=gnu99 -O3 -Wall -Wextra $(pkg-config tree-sitter --cflags)" \
-CXXFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 -Wall -Wextra $(pkg-config tree-sitter --cflags)" \
-LDFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 $(pkg-config tree-sitter --libs)" \
+CFLAGS=$TREE_SITTER_CFLAGS \
+CXXFLAGS=$TREE_SITTER_CXXFLAGS \
+LDFLAGS=$TREE_SITTER_LDFLAGS \
 PREFIX=$TMP_BUILD_DIR/build make install
 popd
 
@@ -26,9 +28,9 @@ git clone https://github.com/alex-pinkus/tree-sitter-swift.git
 
 pushd tree-sitter-swift
 npm install
-CFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 $(pkg-config tree-sitter --cflags)" \
-CXXFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 $(pkg-config tree-sitter --cflags)" \
-LDFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 $(pkg-config tree-sitter --libs)" \
+CFLAGS=$TREE_SITTER_CFLAGS \
+CXXFLAGS=$TREE_SITTER_CXXFLAGS \
+LDFLAGS=$TREE_SITTER_LDFLAGS \
 PREFIX=$TMP_BUILD_DIR/build make install
 popd
 
@@ -36,9 +38,9 @@ git clone https://github.com/tree-sitter/tree-sitter-go.git
 
 pushd tree-sitter-go
 npm install
-CFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 $(pkg-config tree-sitter --cflags)" \
-CXXFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 $(pkg-config tree-sitter --cflags)" \
-LDFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 $(pkg-config tree-sitter --libs)" \
+CFLAGS=$TREE_SITTER_CFLAGS \
+CXXFLAGS=$TREE_SITTER_CXXFLAGS \
+LDFLAGS=$TREE_SITTER_LDFLAGS \
 PREFIX=$TMP_BUILD_DIR/build make install
 popd
 
@@ -46,9 +48,9 @@ git clone https://github.com/camdencheek/tree-sitter-go-mod.git
 
 pushd tree-sitter-go-mod
 npm install
-CFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 $(pkg-config tree-sitter --cflags)" \
-CXXFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 $(pkg-config tree-sitter --cflags)" \
-LDFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 $(pkg-config tree-sitter --libs)" \
+CFLAGS=$TREE_SITTER_CFLAGS \
+CXXFLAGS=$TREE_SITTER_CXXFLAGS \
+LDFLAGS=$TREE_SITTER_LDFLAGS \
 PREFIX=$TMP_BUILD_DIR/build make install
 popd
 
@@ -57,9 +59,9 @@ git clone https://github.com/tree-sitter/tree-sitter-ruby.git
 pushd tree-sitter-ruby
 gh pr checkout 199
 npm install
-CFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 $(pkg-config tree-sitter --cflags)" \
-CXXFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 $(pkg-config tree-sitter --cflags)" \
-LDFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 $(pkg-config tree-sitter --libs)" \
+CFLAGS=$TREE_SITTER_CFLAGS \
+CXXFLAGS=$TREE_SITTER_CXXFLAGS \
+LDFLAGS=$TREE_SITTER_LDFLAGS \
 PREFIX=$TMP_BUILD_DIR/build make install
 popd
 
@@ -68,9 +70,9 @@ git clone https://github.com/tree-sitter/tree-sitter-json.git
 pushd tree-sitter-json
 gh pr checkout 19
 npm install
-CFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 $(pkg-config tree-sitter --cflags)" \
-CXXFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 -O3 $(pkg-config tree-sitter --cflags)" \
-LDFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13 $(pkg-config tree-sitter --libs)" \
+CFLAGS=$TREE_SITTER_CFLAGS \
+CXXFLAGS=$TREE_SITTER_CXXFLAGS \
+LDFLAGS=$TREE_SITTER_LDFLAGS \
 PREFIX=$TMP_BUILD_DIR/build make install
 popd
 


### PR DESCRIPTION
I've just realized that the script will build tree-sitter, but *link* to whatever copy `pkgconfg` reports. This means that the built runtime is not necessarily what is included in the xcframework.

If everything looks good, the binary included is the result of this invocation.