### PR TITLE
LanguageData and Queries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,13 +8,20 @@ let package = Package(
     products: [
         .library(
             name: "tree_sitter",
-            targets: ["tree_sitter"]),
+            targets: ["tree_sitter", "tree_sitter_language_resources"]),
     ],
     dependencies: [],
     targets: [
         .binaryTarget(
             name: "tree_sitter",
             path: "tree_sitter.xcframework"
+        ),
+        .target(
+            name: "tree_sitter_language_resources",
+            dependencies: ["tree_sitter"],
+            resources: [
+                .copy("LanguageResources")
+            ]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ dependencies: [
 ]
 ```
 
+## Usage
+
+Accessing the parsers directly:
+
+```swift
+import tree_sitter
+
+let parser = tree_sitter_swift()
+```
+
+Via the included "LanguageResources" abstraction:
+
+```swift
+import tree_sitter_language_resources
+
+let swift = LanguageResource.swift
+
+let url = swift.highlightQueryURL
+let parserPtr = swift.parser
+```
+
 ### Suggestions or Feedback
 
 I'd love to hear from you! Get in touch via twitter [@krzyzanowskim](https://twitter.com/krzyzanowskim), an issue, or a pull request.

--- a/Sources/tree_sitter_language_resources/LanguageResource.swift
+++ b/Sources/tree_sitter_language_resources/LanguageResource.swift
@@ -1,0 +1,54 @@
+import Foundation
+import tree_sitter
+
+public enum LanguageResource: CaseIterable, Hashable {
+    case go
+    case gomod
+    case json
+    case ruby
+    case swift
+
+    var queryDirectoryName: String {
+        switch self {
+        case .go:
+            return "go"
+        case .gomod:
+            return "gomod"
+        case .json:
+            return "json"
+        case .ruby:
+            return "ruby"
+        case .swift:
+            return "swift"
+        }
+    }
+
+    public var parser: UnsafeMutablePointer<TSLanguage> {
+        switch self {
+        case .go:
+            return tree_sitter_go()
+        case .gomod:
+            return tree_sitter_gomod()
+        case .json:
+            return tree_sitter_json()
+        case .ruby:
+            return tree_sitter_ruby()
+        case .swift:
+            return tree_sitter_swift()
+        }
+    }
+
+    public func scmFileURL(named name: String) -> URL? {
+        return Bundle.module.url(forResource: name,
+                                 withExtension: "scm",
+                                 subdirectory: "LanguageResources/\(queryDirectoryName)")
+    }
+
+    public var highlightQueryURL: URL? {
+        return scmFileURL(named: "highlights")
+    }
+
+    public var localsQueryURL: URL? {
+        return scmFileURL(named: "locals")
+    }
+}

--- a/Sources/tree_sitter_language_resources/LanguageResources/go/highlights.scm
+++ b/Sources/tree_sitter_language_resources/LanguageResources/go/highlights.scm
@@ -1,0 +1,119 @@
+; Function calls
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @function.method))
+
+; Function definitions
+
+(function_declaration
+  name: (identifier) @function)
+
+(method_declaration
+  name: (field_identifier) @function.method)
+
+; Identifiers
+
+(type_identifier) @type
+(field_identifier) @property
+(identifier) @variable
+
+; Operators
+
+[
+  "--"
+  "-"
+  "-="
+  ":="
+  "!"
+  "!="
+  "..."
+  "*"
+  "*"
+  "*="
+  "/"
+  "/="
+  "&"
+  "&&"
+  "&="
+  "%"
+  "%="
+  "^"
+  "^="
+  "+"
+  "++"
+  "+="
+  "<-"
+  "<"
+  "<<"
+  "<<="
+  "<="
+  "="
+  "=="
+  ">"
+  ">="
+  ">>"
+  ">>="
+  "|"
+  "|="
+  "||"
+  "~"
+] @operator
+
+; Keywords
+
+[
+  "break"
+  "case"
+  "chan"
+  "const"
+  "continue"
+  "default"
+  "defer"
+  "else"
+  "fallthrough"
+  "for"
+  "func"
+  "go"
+  "goto"
+  "if"
+  "import"
+  "interface"
+  "map"
+  "package"
+  "range"
+  "return"
+  "select"
+  "struct"
+  "switch"
+  "type"
+  "var"
+] @keyword
+
+; Literals
+
+[
+  (interpreted_string_literal)
+  (raw_string_literal)
+  (rune_literal)
+] @string
+
+(escape_sequence) @escape
+
+[
+  (int_literal)
+  (float_literal)
+  (imaginary_literal)
+] @number
+
+[
+  (true)
+  (false)
+  (nil)
+  (iota)
+] @constant.builtin
+
+(comment) @comment

--- a/Sources/tree_sitter_language_resources/LanguageResources/go/tags.scm
+++ b/Sources/tree_sitter_language_resources/LanguageResources/go/tags.scm
@@ -1,0 +1,30 @@
+(
+  (comment)* @doc
+  .
+  (function_declaration
+    name: (identifier) @name) @definition.function
+  (#strip! @doc "^//\\s*")
+  (#set-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (method_declaration
+    name: (field_identifier) @name) @definition.method
+  (#strip! @doc "^//\\s*")
+  (#set-adjacent! @doc @definition.method)
+)
+
+(call_expression
+  function: [
+    (identifier) @name
+    (parenthesized_expression (identifier) @name)
+    (selector_expression field: (field_identifier) @name)
+    (parenthesized_expression (selector_expression field: (field_identifier) @name))
+  ]) @reference.call
+
+(type_spec
+  name: (type_identifier) @name) @definition.type
+
+(type_identifier) @name @reference.type

--- a/Sources/tree_sitter_language_resources/LanguageResources/gomod/highlights.scm
+++ b/Sources/tree_sitter_language_resources/LanguageResources/gomod/highlights.scm
@@ -1,0 +1,17 @@
+[
+  "require"
+  "replace"
+  "go"
+  "exclude"
+  "retract"
+  "module"
+] @keyword
+
+"=>" @operator
+
+(comment) @comment
+
+[
+(version)
+(go_version)
+] @string

--- a/Sources/tree_sitter_language_resources/LanguageResources/json/highlights.scm
+++ b/Sources/tree_sitter_language_resources/LanguageResources/json/highlights.scm
@@ -1,0 +1,9 @@
+(pair
+  key: (_) @keyword)
+
+(string) @string
+
+(object
+  "{" @escape
+  (_)
+  "}" @escape)

--- a/Sources/tree_sitter_language_resources/LanguageResources/ruby/highlights.scm
+++ b/Sources/tree_sitter_language_resources/LanguageResources/ruby/highlights.scm
@@ -1,0 +1,154 @@
+; Keywords
+
+[
+  "alias"
+  "and"
+  "begin"
+  "break"
+  "case"
+  "class"
+  "def"
+  "do"
+  "else"
+  "elsif"
+  "end"
+  "ensure"
+  "for"
+  "if"
+  "in"
+  "module"
+  "next"
+  "or"
+  "rescue"
+  "retry"
+  "return"
+  "then"
+  "unless"
+  "until"
+  "when"
+  "while"
+  "yield"
+] @keyword
+
+((identifier) @keyword
+ (#match? @keyword "^(private|protected|public)$"))
+
+; Function calls
+
+((identifier) @function.method.builtin
+ (#eq? @function.method.builtin "require"))
+
+"defined?" @function.method.builtin
+
+(call
+  method: [(identifier) (constant)] @function.method)
+
+; Function definitions
+
+(alias (identifier) @function.method)
+(setter (identifier) @function.method)
+(method name: [(identifier) (constant)] @function.method)
+(singleton_method name: [(identifier) (constant)] @function.method)
+
+; Identifiers
+
+[
+  (class_variable)
+  (instance_variable)
+] @property
+
+((identifier) @constant.builtin
+ (#match? @constant.builtin "^__(FILE|LINE|ENCODING)__$"))
+
+(file) @constant.builtin
+(line) @constant.builtin
+(encoding) @constant.builtin
+
+(hash_splat_nil
+  "**" @operator
+) @constant.builtin
+
+((constant) @constant
+ (#match? @constant "^[A-Z\\d_]+$"))
+
+(constant) @constructor
+
+(self) @variable.builtin
+(super) @variable.builtin
+
+(block_parameter (identifier) @variable.parameter)
+(block_parameters (identifier) @variable.parameter)
+(destructured_parameter (identifier) @variable.parameter)
+(hash_splat_parameter (identifier) @variable.parameter)
+(lambda_parameters (identifier) @variable.parameter)
+(method_parameters (identifier) @variable.parameter)
+(splat_parameter (identifier) @variable.parameter)
+
+(keyword_parameter name: (identifier) @variable.parameter)
+(optional_parameter name: (identifier) @variable.parameter)
+
+((identifier) @function.method
+ (#is-not? local))
+(identifier) @variable
+
+; Literals
+
+[
+  (string)
+  (bare_string)
+  (subshell)
+  (heredoc_body)
+  (heredoc_beginning)
+] @string
+
+[
+  (simple_symbol)
+  (delimited_symbol)
+  (hash_key_symbol)
+  (bare_symbol)
+] @string.special.symbol
+
+(regex) @string.special.regex
+(escape_sequence) @escape
+
+[
+  (integer)
+  (float)
+] @number
+
+[
+  (nil)
+  (true)
+  (false)
+]@constant.builtin
+
+(interpolation
+  "#{" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+(comment) @comment
+
+; Operators
+
+[
+"="
+"=>"
+"->"
+] @operator
+
+[
+  ","
+  ";"
+  "."
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "%w("
+  "%i("
+] @punctuation.bracket

--- a/Sources/tree_sitter_language_resources/LanguageResources/ruby/locals.scm
+++ b/Sources/tree_sitter_language_resources/LanguageResources/ruby/locals.scm
@@ -1,0 +1,27 @@
+((method) @local.scope
+ (#set! local.scope-inherits false))
+
+[
+  (lambda)
+  (block)
+  (do_block)
+] @local.scope
+
+(block_parameter (identifier) @local.definition)
+(block_parameters (identifier) @local.definition)
+(destructured_parameter (identifier) @local.definition)
+(hash_splat_parameter (identifier) @local.definition)
+(lambda_parameters (identifier) @local.definition)
+(method_parameters (identifier) @local.definition)
+(splat_parameter (identifier) @local.definition)
+
+(keyword_parameter name: (identifier) @local.definition)
+(optional_parameter name: (identifier) @local.definition)
+
+(identifier) @local.reference
+
+(assignment left: (identifier) @local.definition)
+(operator_assignment left: (identifier) @local.definition)
+(left_assignment_list (identifier) @local.definition)
+(rest_assignment (identifier) @local.definition)
+(destructured_left_assignment (identifier) @local.definition)

--- a/Sources/tree_sitter_language_resources/LanguageResources/ruby/tags.scm
+++ b/Sources/tree_sitter_language_resources/LanguageResources/ruby/tags.scm
@@ -1,0 +1,64 @@
+; Method definitions
+
+(
+  (comment)* @doc
+  .
+  [
+    (method
+      name: (_) @name) @definition.method
+    (singleton_method
+      name: (_) @name) @definition.method
+  ]
+  (#strip! @doc "^#\\s*")
+  (#select-adjacent! @doc @definition.method)
+)
+
+(alias
+  name: (_) @name) @definition.method
+
+(setter
+  (identifier) @ignore)
+
+; Class definitions
+
+(
+  (comment)* @doc
+  .
+  [
+    (class
+      name: [
+        (constant) @name
+        (scope_resolution
+          name: (_) @name)
+      ]) @definition.class
+    (singleton_class
+      value: [
+        (constant) @name
+        (scope_resolution
+          name: (_) @name)
+      ]) @definition.class
+  ]
+  (#strip! @doc "^#\\s*")
+  (#select-adjacent! @doc @definition.class)
+)
+
+; Module definitions
+
+(
+  (module
+    name: [
+      (constant) @name
+      (scope_resolution
+        name: (_) @name)
+    ]) @definition.module
+)
+
+; Calls
+
+(call method: (identifier) @name) @reference.call
+
+(
+  [(identifier) (constant)] @name @reference.call
+  (#is-not? local)
+  (#not-match? @name "^(lambda|load|require|require_relative|__FILE__|__LINE__)$")
+)

--- a/Sources/tree_sitter_language_resources/LanguageResources/swift/highlights.scm
+++ b/Sources/tree_sitter_language_resources/LanguageResources/swift/highlights.scm
@@ -1,0 +1,157 @@
+[ "." ";" ":" "," ] @punctuation.delimiter
+[ "\\(" "(" ")" "[" "]" "{" "}"] @punctuation.bracket ; TODO: "\\(" ")" in interpolations should be @punctuation.special
+
+; Identifiers
+(attribute) @variable
+(simple_identifier) @variable
+(type_identifier) @type
+(self_expression) @variable.builtin
+
+; Declarations
+"func" @keyword.function
+[
+  (visibility_modifier)
+  (member_modifier)
+  (function_modifier)
+  (property_modifier)
+  (parameter_modifier)
+  (inheritance_modifier)
+] @keyword
+
+(function_declaration (simple_identifier) @method)
+(function_declaration ["init" @constructor])
+(throws) @keyword
+"async" @keyword
+(where_keyword) @keyword
+(parameter external_name: (simple_identifier) @parameter)
+(parameter name: (simple_identifier) @parameter)
+(type_parameter (type_identifier) @parameter)
+(inheritance_constraint (identifier (simple_identifier) @parameter))
+(equality_constraint (identifier (simple_identifier) @parameter))
+
+[
+  "typealias"
+  "struct"
+  "class"
+  "enum"
+  "protocol"
+  "extension"
+  "indirect"
+] @keyword
+
+[
+  (getter_specifier)
+  (setter_specifier)
+  (modify_specifier)
+] @keyword
+
+(class_body (property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property))))
+(protocol_property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property)))
+
+(import_declaration ["import" @include])
+
+(enum_entry ["case" @keyword])
+
+; Function calls
+(call_expression (simple_identifier) @function) ; foo()
+(call_expression ; foo.bar.baz(): highlight the baz()
+  (navigation_expression
+    (navigation_suffix (simple_identifier) @function)))
+((navigation_expression
+   (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
+   (#match? @type "^[A-Z]"))
+
+(directive) @function.macro
+(diagnostic) @function.macro
+
+; Statements
+(for_statement ["for" @repeat])
+(for_statement ["in" @repeat])
+(for_statement item: (simple_identifier) @variable)
+(else) @keyword
+(as_operator) @keyword
+
+["while" "repeat" "continue" "break"] @repeat
+
+["let" "var"] @keyword
+(non_binding_pattern (simple_identifier) @variable)
+
+(guard_statement ["guard" @conditional])
+(if_statement ["if" @conditional])
+(switch_statement ["switch" @conditional])
+(switch_entry ["case" @keyword])
+(switch_entry ["fallthrough" @keyword])
+(switch_entry (default_keyword) @keyword)
+"return" @keyword.return
+(ternary_expression
+  ["?" ":"] @conditional)
+
+["do" (throw_keyword) (catch_keyword)] @keyword
+
+(statement_label) @label
+
+; Comments
+(comment) @comment
+(multiline_comment) @comment
+
+; String literals
+(line_str_text) @string
+(str_escaped_char) @string
+(multi_line_str_text) @string
+(raw_str_part) @string
+(raw_str_end_part) @string
+(raw_str_interpolation_start) @punctuation.special
+["\"" "\"\"\""] @string
+
+; Lambda literals
+(lambda_literal ["in" @keyword.operator])
+
+; Basic literals
+[
+ (integer_literal)
+ (hex_literal)
+ (oct_literal)
+ (bin_literal)
+] @number
+(real_literal) @float
+(boolean_literal) @boolean
+"nil" @variable.builtin
+
+; Operators
+(custom_operator) @operator
+[
+ "try"
+ "try?"
+ "try!"
+ "!"
+ "+"
+ "-"
+ "*"
+ "/"
+ "%"
+ "="
+ "+="
+ "-="
+ "*="
+ "/="
+ "<"
+ ">"
+ "<="
+ ">="
+ "++"
+ "--"
+ "&"
+ "~"
+ "%="
+ "!="
+ "!=="
+ "=="
+ "==="
+ "??"
+
+ "->"
+
+ "..<"
+ "..."
+] @operator
+

--- a/Sources/tree_sitter_language_resources/LanguageResources/swift/locals.scm
+++ b/Sources/tree_sitter_language_resources/LanguageResources/swift/locals.scm
@@ -1,0 +1,18 @@
+(import_declaration (identifier) @definition.import)
+(function_declaration name: (simple_identifier) @definition.function)
+
+; Scopes
+[
+ (statements)
+ (for_statement)
+ (while_statement)
+ (repeat_while_statement)
+ (do_statement)
+ (if_statement)
+ (guard_statement)
+ (switch_statement)
+ (property_declaration)
+ (function_declaration)
+ (class_declaration)
+ (protocol_declaration)
+] @scope

--- a/scripts/Sources/tree_sitter_language_data/LanguageData/go/highlights.scm
+++ b/scripts/Sources/tree_sitter_language_data/LanguageData/go/highlights.scm
@@ -1,0 +1,119 @@
+; Function calls
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @function.method))
+
+; Function definitions
+
+(function_declaration
+  name: (identifier) @function)
+
+(method_declaration
+  name: (field_identifier) @function.method)
+
+; Identifiers
+
+(type_identifier) @type
+(field_identifier) @property
+(identifier) @variable
+
+; Operators
+
+[
+  "--"
+  "-"
+  "-="
+  ":="
+  "!"
+  "!="
+  "..."
+  "*"
+  "*"
+  "*="
+  "/"
+  "/="
+  "&"
+  "&&"
+  "&="
+  "%"
+  "%="
+  "^"
+  "^="
+  "+"
+  "++"
+  "+="
+  "<-"
+  "<"
+  "<<"
+  "<<="
+  "<="
+  "="
+  "=="
+  ">"
+  ">="
+  ">>"
+  ">>="
+  "|"
+  "|="
+  "||"
+  "~"
+] @operator
+
+; Keywords
+
+[
+  "break"
+  "case"
+  "chan"
+  "const"
+  "continue"
+  "default"
+  "defer"
+  "else"
+  "fallthrough"
+  "for"
+  "func"
+  "go"
+  "goto"
+  "if"
+  "import"
+  "interface"
+  "map"
+  "package"
+  "range"
+  "return"
+  "select"
+  "struct"
+  "switch"
+  "type"
+  "var"
+] @keyword
+
+; Literals
+
+[
+  (interpreted_string_literal)
+  (raw_string_literal)
+  (rune_literal)
+] @string
+
+(escape_sequence) @escape
+
+[
+  (int_literal)
+  (float_literal)
+  (imaginary_literal)
+] @number
+
+[
+  (true)
+  (false)
+  (nil)
+  (iota)
+] @constant.builtin
+
+(comment) @comment

--- a/scripts/Sources/tree_sitter_language_data/LanguageData/go/tags.scm
+++ b/scripts/Sources/tree_sitter_language_data/LanguageData/go/tags.scm
@@ -1,0 +1,30 @@
+(
+  (comment)* @doc
+  .
+  (function_declaration
+    name: (identifier) @name) @definition.function
+  (#strip! @doc "^//\\s*")
+  (#set-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (method_declaration
+    name: (field_identifier) @name) @definition.method
+  (#strip! @doc "^//\\s*")
+  (#set-adjacent! @doc @definition.method)
+)
+
+(call_expression
+  function: [
+    (identifier) @name
+    (parenthesized_expression (identifier) @name)
+    (selector_expression field: (field_identifier) @name)
+    (parenthesized_expression (selector_expression field: (field_identifier) @name))
+  ]) @reference.call
+
+(type_spec
+  name: (type_identifier) @name) @definition.type
+
+(type_identifier) @name @reference.type

--- a/scripts/Sources/tree_sitter_language_data/LanguageData/gomod/highlights.scm
+++ b/scripts/Sources/tree_sitter_language_data/LanguageData/gomod/highlights.scm
@@ -1,0 +1,17 @@
+[
+  "require"
+  "replace"
+  "go"
+  "exclude"
+  "retract"
+  "module"
+] @keyword
+
+"=>" @operator
+
+(comment) @comment
+
+[
+(version)
+(go_version)
+] @string

--- a/scripts/Sources/tree_sitter_language_data/LanguageData/json/highlights.scm
+++ b/scripts/Sources/tree_sitter_language_data/LanguageData/json/highlights.scm
@@ -1,0 +1,9 @@
+(pair
+  key: (_) @keyword)
+
+(string) @string
+
+(object
+  "{" @escape
+  (_)
+  "}" @escape)

--- a/scripts/Sources/tree_sitter_language_data/LanguageData/ruby/highlights.scm
+++ b/scripts/Sources/tree_sitter_language_data/LanguageData/ruby/highlights.scm
@@ -1,0 +1,154 @@
+; Keywords
+
+[
+  "alias"
+  "and"
+  "begin"
+  "break"
+  "case"
+  "class"
+  "def"
+  "do"
+  "else"
+  "elsif"
+  "end"
+  "ensure"
+  "for"
+  "if"
+  "in"
+  "module"
+  "next"
+  "or"
+  "rescue"
+  "retry"
+  "return"
+  "then"
+  "unless"
+  "until"
+  "when"
+  "while"
+  "yield"
+] @keyword
+
+((identifier) @keyword
+ (#match? @keyword "^(private|protected|public)$"))
+
+; Function calls
+
+((identifier) @function.method.builtin
+ (#eq? @function.method.builtin "require"))
+
+"defined?" @function.method.builtin
+
+(call
+  method: [(identifier) (constant)] @function.method)
+
+; Function definitions
+
+(alias (identifier) @function.method)
+(setter (identifier) @function.method)
+(method name: [(identifier) (constant)] @function.method)
+(singleton_method name: [(identifier) (constant)] @function.method)
+
+; Identifiers
+
+[
+  (class_variable)
+  (instance_variable)
+] @property
+
+((identifier) @constant.builtin
+ (#match? @constant.builtin "^__(FILE|LINE|ENCODING)__$"))
+
+(file) @constant.builtin
+(line) @constant.builtin
+(encoding) @constant.builtin
+
+(hash_splat_nil
+  "**" @operator
+) @constant.builtin
+
+((constant) @constant
+ (#match? @constant "^[A-Z\\d_]+$"))
+
+(constant) @constructor
+
+(self) @variable.builtin
+(super) @variable.builtin
+
+(block_parameter (identifier) @variable.parameter)
+(block_parameters (identifier) @variable.parameter)
+(destructured_parameter (identifier) @variable.parameter)
+(hash_splat_parameter (identifier) @variable.parameter)
+(lambda_parameters (identifier) @variable.parameter)
+(method_parameters (identifier) @variable.parameter)
+(splat_parameter (identifier) @variable.parameter)
+
+(keyword_parameter name: (identifier) @variable.parameter)
+(optional_parameter name: (identifier) @variable.parameter)
+
+((identifier) @function.method
+ (#is-not? local))
+(identifier) @variable
+
+; Literals
+
+[
+  (string)
+  (bare_string)
+  (subshell)
+  (heredoc_body)
+  (heredoc_beginning)
+] @string
+
+[
+  (simple_symbol)
+  (delimited_symbol)
+  (hash_key_symbol)
+  (bare_symbol)
+] @string.special.symbol
+
+(regex) @string.special.regex
+(escape_sequence) @escape
+
+[
+  (integer)
+  (float)
+] @number
+
+[
+  (nil)
+  (true)
+  (false)
+]@constant.builtin
+
+(interpolation
+  "#{" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+(comment) @comment
+
+; Operators
+
+[
+"="
+"=>"
+"->"
+] @operator
+
+[
+  ","
+  ";"
+  "."
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "%w("
+  "%i("
+] @punctuation.bracket

--- a/scripts/Sources/tree_sitter_language_data/LanguageData/ruby/locals.scm
+++ b/scripts/Sources/tree_sitter_language_data/LanguageData/ruby/locals.scm
@@ -1,0 +1,27 @@
+((method) @local.scope
+ (#set! local.scope-inherits false))
+
+[
+  (lambda)
+  (block)
+  (do_block)
+] @local.scope
+
+(block_parameter (identifier) @local.definition)
+(block_parameters (identifier) @local.definition)
+(destructured_parameter (identifier) @local.definition)
+(hash_splat_parameter (identifier) @local.definition)
+(lambda_parameters (identifier) @local.definition)
+(method_parameters (identifier) @local.definition)
+(splat_parameter (identifier) @local.definition)
+
+(keyword_parameter name: (identifier) @local.definition)
+(optional_parameter name: (identifier) @local.definition)
+
+(identifier) @local.reference
+
+(assignment left: (identifier) @local.definition)
+(operator_assignment left: (identifier) @local.definition)
+(left_assignment_list (identifier) @local.definition)
+(rest_assignment (identifier) @local.definition)
+(destructured_left_assignment (identifier) @local.definition)

--- a/scripts/Sources/tree_sitter_language_data/LanguageData/ruby/tags.scm
+++ b/scripts/Sources/tree_sitter_language_data/LanguageData/ruby/tags.scm
@@ -1,0 +1,64 @@
+; Method definitions
+
+(
+  (comment)* @doc
+  .
+  [
+    (method
+      name: (_) @name) @definition.method
+    (singleton_method
+      name: (_) @name) @definition.method
+  ]
+  (#strip! @doc "^#\\s*")
+  (#select-adjacent! @doc @definition.method)
+)
+
+(alias
+  name: (_) @name) @definition.method
+
+(setter
+  (identifier) @ignore)
+
+; Class definitions
+
+(
+  (comment)* @doc
+  .
+  [
+    (class
+      name: [
+        (constant) @name
+        (scope_resolution
+          name: (_) @name)
+      ]) @definition.class
+    (singleton_class
+      value: [
+        (constant) @name
+        (scope_resolution
+          name: (_) @name)
+      ]) @definition.class
+  ]
+  (#strip! @doc "^#\\s*")
+  (#select-adjacent! @doc @definition.class)
+)
+
+; Module definitions
+
+(
+  (module
+    name: [
+      (constant) @name
+      (scope_resolution
+        name: (_) @name)
+    ]) @definition.module
+)
+
+; Calls
+
+(call method: (identifier) @name) @reference.call
+
+(
+  [(identifier) (constant)] @name @reference.call
+  (#is-not? local)
+  (#not-match? @name "^(lambda|load|require|require_relative|__FILE__|__LINE__)$")
+)

--- a/scripts/Sources/tree_sitter_language_data/LanguageData/swift/highlights.scm
+++ b/scripts/Sources/tree_sitter_language_data/LanguageData/swift/highlights.scm
@@ -1,0 +1,157 @@
+[ "." ";" ":" "," ] @punctuation.delimiter
+[ "\\(" "(" ")" "[" "]" "{" "}"] @punctuation.bracket ; TODO: "\\(" ")" in interpolations should be @punctuation.special
+
+; Identifiers
+(attribute) @variable
+(simple_identifier) @variable
+(type_identifier) @type
+(self_expression) @variable.builtin
+
+; Declarations
+"func" @keyword.function
+[
+  (visibility_modifier)
+  (member_modifier)
+  (function_modifier)
+  (property_modifier)
+  (parameter_modifier)
+  (inheritance_modifier)
+] @keyword
+
+(function_declaration (simple_identifier) @method)
+(function_declaration ["init" @constructor])
+(throws) @keyword
+"async" @keyword
+(where_keyword) @keyword
+(parameter external_name: (simple_identifier) @parameter)
+(parameter name: (simple_identifier) @parameter)
+(type_parameter (type_identifier) @parameter)
+(inheritance_constraint (identifier (simple_identifier) @parameter))
+(equality_constraint (identifier (simple_identifier) @parameter))
+
+[
+  "typealias"
+  "struct"
+  "class"
+  "enum"
+  "protocol"
+  "extension"
+  "indirect"
+] @keyword
+
+[
+  (getter_specifier)
+  (setter_specifier)
+  (modify_specifier)
+] @keyword
+
+(class_body (property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property))))
+(protocol_property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property)))
+
+(import_declaration ["import" @include])
+
+(enum_entry ["case" @keyword])
+
+; Function calls
+(call_expression (simple_identifier) @function) ; foo()
+(call_expression ; foo.bar.baz(): highlight the baz()
+  (navigation_expression
+    (navigation_suffix (simple_identifier) @function)))
+((navigation_expression
+   (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
+   (#match? @type "^[A-Z]"))
+
+(directive) @function.macro
+(diagnostic) @function.macro
+
+; Statements
+(for_statement ["for" @repeat])
+(for_statement ["in" @repeat])
+(for_statement item: (simple_identifier) @variable)
+(else) @keyword
+(as_operator) @keyword
+
+["while" "repeat" "continue" "break"] @repeat
+
+["let" "var"] @keyword
+(non_binding_pattern (simple_identifier) @variable)
+
+(guard_statement ["guard" @conditional])
+(if_statement ["if" @conditional])
+(switch_statement ["switch" @conditional])
+(switch_entry ["case" @keyword])
+(switch_entry ["fallthrough" @keyword])
+(switch_entry (default_keyword) @keyword)
+"return" @keyword.return
+(ternary_expression
+  ["?" ":"] @conditional)
+
+["do" (throw_keyword) (catch_keyword)] @keyword
+
+(statement_label) @label
+
+; Comments
+(comment) @comment
+(multiline_comment) @comment
+
+; String literals
+(line_str_text) @string
+(str_escaped_char) @string
+(multi_line_str_text) @string
+(raw_str_part) @string
+(raw_str_end_part) @string
+(raw_str_interpolation_start) @punctuation.special
+["\"" "\"\"\""] @string
+
+; Lambda literals
+(lambda_literal ["in" @keyword.operator])
+
+; Basic literals
+[
+ (integer_literal)
+ (hex_literal)
+ (oct_literal)
+ (bin_literal)
+] @number
+(real_literal) @float
+(boolean_literal) @boolean
+"nil" @variable.builtin
+
+; Operators
+(custom_operator) @operator
+[
+ "try"
+ "try?"
+ "try!"
+ "!"
+ "+"
+ "-"
+ "*"
+ "/"
+ "%"
+ "="
+ "+="
+ "-="
+ "*="
+ "/="
+ "<"
+ ">"
+ "<="
+ ">="
+ "++"
+ "--"
+ "&"
+ "~"
+ "%="
+ "!="
+ "!=="
+ "=="
+ "==="
+ "??"
+
+ "->"
+
+ "..<"
+ "..."
+] @operator
+

--- a/scripts/Sources/tree_sitter_language_data/LanguageData/swift/locals.scm
+++ b/scripts/Sources/tree_sitter_language_data/LanguageData/swift/locals.scm
@@ -1,0 +1,18 @@
+(import_declaration (identifier) @definition.import)
+(function_declaration name: (simple_identifier) @definition.function)
+
+; Scopes
+[
+ (statements)
+ (for_statement)
+ (while_statement)
+ (repeat_while_statement)
+ (do_statement)
+ (if_statement)
+ (guard_statement)
+ (switch_statement)
+ (property_declaration)
+ (function_declaration)
+ (class_declaration)
+ (protocol_declaration)
+] @scope

--- a/scripts/build-tree-sitter.sh
+++ b/scripts/build-tree-sitter.sh
@@ -11,6 +11,7 @@ PKG_CONFIG_PATH="$TMP_BUILD_DIR/build/lib/pkgconfig"
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:+:}${PKG_CONFIG_PATH}:$(pkg-config --variable pc_path pkg-config)
 
 COMMON_FLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=10.13"
+LANGUAGE_DATA_DIR="$SCRIPT_DIR/../Sources/tree_sitter_language_resources/LanguageResources"
 
 pushd $TMP_BUILD_DIR
 
@@ -32,6 +33,8 @@ CFLAGS="${COMMON_FLAGS} -O3 $(pkg-config tree-sitter --cflags)" \
 CXXFLAGS="${COMMON_FLAGS} -O3 $(pkg-config tree-sitter --cflags)" \
 LDFLAGS="${COMMON_FLAGS} $(pkg-config tree-sitter --libs)" \
 PREFIX=$TMP_BUILD_DIR/build make install
+mkdir -p "$LANGUAGE_DATA_DIR/swift"
+cp queries/* "$LANGUAGE_DATA_DIR/swift/"
 popd
 
 git clone https://github.com/tree-sitter/tree-sitter-go.git
@@ -42,6 +45,8 @@ CFLAGS="${COMMON_FLAGS} -O3 $(pkg-config tree-sitter --cflags)" \
 CXXFLAGS="${COMMON_FLAGS} -O3 $(pkg-config tree-sitter --cflags)" \
 LDFLAGS="${COMMON_FLAGS} $(pkg-config tree-sitter --libs)" \
 PREFIX=$TMP_BUILD_DIR/build make install
+mkdir -p "$LANGUAGE_DATA_DIR/go"
+cp queries/* "$LANGUAGE_DATA_DIR/go/"
 popd
 
 git clone https://github.com/camdencheek/tree-sitter-go-mod.git
@@ -52,6 +57,8 @@ CFLAGS="${COMMON_FLAGS} -O3 $(pkg-config tree-sitter --cflags)" \
 CXXFLAGS="${COMMON_FLAGS} -O3 $(pkg-config tree-sitter --cflags)" \
 LDFLAGS="${COMMON_FLAGS} $(pkg-config tree-sitter --libs)" \
 PREFIX=$TMP_BUILD_DIR/build make install
+mkdir -p "$LANGUAGE_DATA_DIR/gomod"
+cp queries/* "$LANGUAGE_DATA_DIR/gomod/"
 popd
 
 git clone https://github.com/tree-sitter/tree-sitter-ruby.git
@@ -63,6 +70,8 @@ CFLAGS="${COMMON_FLAGS} -O3 $(pkg-config tree-sitter --cflags)" \
 CXXFLAGS="${COMMON_FLAGS} -O3 $(pkg-config tree-sitter --cflags)" \
 LDFLAGS="${COMMON_FLAGS} $(pkg-config tree-sitter --libs)" \
 PREFIX=$TMP_BUILD_DIR/build make install
+mkdir -p "$LANGUAGE_DATA_DIR/ruby"
+cp queries/* "$LANGUAGE_DATA_DIR/ruby/"
 popd
 
 git clone https://github.com/tree-sitter/tree-sitter-json.git
@@ -74,6 +83,8 @@ CFLAGS="${COMMON_FLAGS} -O3 $(pkg-config tree-sitter --cflags)" \
 CXXFLAGS="${COMMON_FLAGS} -O3 $(pkg-config tree-sitter --cflags)" \
 LDFLAGS="${COMMON_FLAGS} $(pkg-config tree-sitter --libs)" \
 PREFIX=$TMP_BUILD_DIR/build make install
+mkdir -p "$LANGUAGE_DATA_DIR/json"
+cp queries/* "$LANGUAGE_DATA_DIR/json/"
 popd
 
 libtool -static -o libtree-sitter.a \


### PR DESCRIPTION
This project makes using tree-sitter much easier. But, one big missing piece is query definitions.

As far as I can tell, resources added to the subframeworks in a xcframework are not easily accessible from package clients. Further, the `binaryTarget` does not support bundling resource. So, I opted for a new, regular `target` that does allow resources.

Since I was already doing this, I created a simple enum type `LanguageData` that gives you very easy access to the bundled parsers and their queries. This also give you easy access to both compile- and runtime-information about what languages are available via this package. But, of course, I'm open to other ideas!

usage:

```swift
import tree_sitter_language_resources

let swift = LanguageResource.swift

let url = swift.highlightQueryURL
let parserPtr = swift.parser
```